### PR TITLE
Edit PayPal link to non-profit

### DIFF
--- a/public/assets/lesson-subject.js
+++ b/public/assets/lesson-subject.js
@@ -27,7 +27,7 @@ window.addEventListener("load", function() {
     "God the Preserver of Man",
     "Is the Universe, Including Man, Evolved by Atomic Force?"
   ];
-  var startDate = moment("2016-06-27");
+  var startDate = moment("2023-12-25");
   var weeksSinceStart = moment().diff(startDate, "weeks");
   var subjectIndex = weeksSinceStart % subjects.length;
   var currentSubject = subjects[subjectIndex];

--- a/public/index.html
+++ b/public/index.html
@@ -129,10 +129,7 @@ the writings of Mary Baker Eddy, and Christian Science publications.</p>
   </div>
 
   <footer class=footer>
-<!--
-    <p><a href="https://www.paypal.com/cgi-bin/webscr?cmd=_s-xclick&amp;hosted_button_id=VSFAVRMSSEW36&amp;source=url" target="_blank" rel="noopener"><img class="aligncenter wp-image-333 size-full" src="/assets/paypal-button.png" alt="Donate now via PayPal" width="100" height="49"></a></p>
--->
-    <p><a href="https://www.paypal.com/donate/?hosted_button_id=9S5EZGFUNTFNQ;source=url" target="_blank" rel="noopener"><img class="aligncenter wp-image-333 size-full" src="/assets/paypal-button.png" alt="Donate now via PayPal" width="100" height="49"></a></p>
+    <p><a href="https://www.paypal.com/donate/?hosted_button_id=9S5EZGFUNTFNQ" target="_blank" rel="noopener"><img class="aligncenter wp-image-333 size-full" src="/assets/paypal-button.png" alt="Donate now via PayPal" width="100" height="49"></a></p>
     <span class=copyright>First Church of Christ, Scientist</span>
     <address>600 E Melbourne Ave, Melbourne, FL 32901</address>
   </footer>

--- a/public/index.html
+++ b/public/index.html
@@ -129,7 +129,10 @@ the writings of Mary Baker Eddy, and Christian Science publications.</p>
   </div>
 
   <footer class=footer>
+<!--
     <p><a href="https://www.paypal.com/cgi-bin/webscr?cmd=_s-xclick&amp;hosted_button_id=VSFAVRMSSEW36&amp;source=url" target="_blank" rel="noopener"><img class="aligncenter wp-image-333 size-full" src="/assets/paypal-button.png" alt="Donate now via PayPal" width="100" height="49"></a></p>
+-->
+    <p><a href="https://www.paypal.com/donate/?hosted_button_id=9S5EZGFUNTFNQ;source=url" target="_blank" rel="noopener"><img class="aligncenter wp-image-333 size-full" src="/assets/paypal-button.png" alt="Donate now via PayPal" width="100" height="49"></a></p>
     <span class=copyright>First Church of Christ, Scientist</span>
     <address>600 E Melbourne Ave, Melbourne, FL 32901</address>
   </footer>

--- a/public/lectures-and-events/Be_Set_Free_2024/index.html
+++ b/public/lectures-and-events/Be_Set_Free_2024/index.html
@@ -82,7 +82,10 @@ Member of the Christian Science Board of Lectureship</p>
   </div>
 
   <footer class=footer>
+<!--
     <p><a href="https://www.paypal.com/cgi-bin/webscr?cmd=_s-xclick&amp;hosted_button_id=VSFAVRMSSEW36&amp;source=url" target="_blank" rel="noopener"><img class="aligncenter wp-image-333 size-full" src="/assets/paypal-button.png" alt="Donate now via PayPal" width="100" height="49"></a></p>
+-->
+    <p><a href="https://www.paypal.com/donate/?hosted_button_id=9S5EZGFUNTFNQ;source=url" target="_blank" rel="noopener"><img class="aligncenter wp-image-333 size-full" src="/assets/paypal-button.png" alt="Donate now via PayPal" width="100" height="49"></a></p>
     <span class=copyright>First Church of Christ, Scientist</span>
     <address>600 E Melbourne Ave, Melbourne, FL 32901</address>
   </footer>

--- a/public/lectures-and-events/Be_Set_Free_2024/index.html
+++ b/public/lectures-and-events/Be_Set_Free_2024/index.html
@@ -82,10 +82,7 @@ Member of the Christian Science Board of Lectureship</p>
   </div>
 
   <footer class=footer>
-<!--
-    <p><a href="https://www.paypal.com/cgi-bin/webscr?cmd=_s-xclick&amp;hosted_button_id=VSFAVRMSSEW36&amp;source=url" target="_blank" rel="noopener"><img class="aligncenter wp-image-333 size-full" src="/assets/paypal-button.png" alt="Donate now via PayPal" width="100" height="49"></a></p>
--->
-    <p><a href="https://www.paypal.com/donate/?hosted_button_id=9S5EZGFUNTFNQ;source=url" target="_blank" rel="noopener"><img class="aligncenter wp-image-333 size-full" src="/assets/paypal-button.png" alt="Donate now via PayPal" width="100" height="49"></a></p>
+    <p><a href="https://www.paypal.com/donate/?hosted_button_id=9S5EZGFUNTFNQ" target="_blank" rel="noopener"><img class="aligncenter wp-image-333 size-full" src="/assets/paypal-button.png" alt="Donate now via PayPal" width="100" height="49"></a></p>
     <span class=copyright>First Church of Christ, Scientist</span>
     <address>600 E Melbourne Ave, Melbourne, FL 32901</address>
   </footer>

--- a/public/online-services/index.html
+++ b/public/online-services/index.html
@@ -71,10 +71,7 @@ feature and wait for the usher to call on you.</p>
   </div>
 
   <footer class=footer>
-<!--
-    <p><a href="https://www.paypal.com/cgi-bin/webscr?cmd=_s-xclick&amp;hosted_button_id=VSFAVRMSSEW36&amp;source=url" target="_blank" rel="noopener"><img class="aligncenter wp-image-333 size-full" src="/assets/paypal-button.png" alt="Donate now via PayPal" width="100" height="49"></a></p>
--->
-    <p><a href="https://www.paypal.com/donate/?hosted_button_id=9S5EZGFUNTFNQ;source=url" target="_blank" rel="noopener"><img class="aligncenter wp-image-333 size-full" src="/assets/paypal-button.png" alt="Donate now via PayPal" width="100" height="49"></a></p>
+    <p><a href="https://www.paypal.com/donate/?hosted_button_id=9S5EZGFUNTFNQ" target="_blank" rel="noopener"><img class="aligncenter wp-image-333 size-full" src="/assets/paypal-button.png" alt="Donate now via PayPal" width="100" height="49"></a></p>
     <span class=copyright>First Church of Christ, Scientist</span>
     <address>600 E Melbourne Ave, Melbourne, FL 32901</address>
   </footer>

--- a/public/online-services/index.html
+++ b/public/online-services/index.html
@@ -71,7 +71,10 @@ feature and wait for the usher to call on you.</p>
   </div>
 
   <footer class=footer>
+<!--
     <p><a href="https://www.paypal.com/cgi-bin/webscr?cmd=_s-xclick&amp;hosted_button_id=VSFAVRMSSEW36&amp;source=url" target="_blank" rel="noopener"><img class="aligncenter wp-image-333 size-full" src="/assets/paypal-button.png" alt="Donate now via PayPal" width="100" height="49"></a></p>
+-->
+    <p><a href="https://www.paypal.com/donate/?hosted_button_id=9S5EZGFUNTFNQ;source=url" target="_blank" rel="noopener"><img class="aligncenter wp-image-333 size-full" src="/assets/paypal-button.png" alt="Donate now via PayPal" width="100" height="49"></a></p>
     <span class=copyright>First Church of Christ, Scientist</span>
     <address>600 E Melbourne Ave, Melbourne, FL 32901</address>
   </footer>

--- a/public/reading-room/index.html
+++ b/public/reading-room/index.html
@@ -83,7 +83,10 @@ make purchases.</p>
   </div>
 
   <footer class=footer>
+<!--
     <p><a href="https://www.paypal.com/cgi-bin/webscr?cmd=_s-xclick&amp;hosted_button_id=VSFAVRMSSEW36&amp;source=url" target="_blank" rel="noopener"><img class="aligncenter wp-image-333 size-full" src="/assets/paypal-button.png" alt="Donate now via PayPal" width="100" height="49"></a></p>
+-->
+    <p><a href="https://www.paypal.com/donate/?hosted_button_id=9S5EZGFUNTFNQ;source=url" target="_blank" rel="noopener"><img class="aligncenter wp-image-333 size-full" src="/assets/paypal-button.png" alt="Donate now via PayPal" width="100" height="49"></a></p>
     <span class=copyright>First Church of Christ, Scientist</span>
     <address>600 E Melbourne Ave, Melbourne, FL 32901</address>
   </footer>

--- a/public/reading-room/index.html
+++ b/public/reading-room/index.html
@@ -83,10 +83,7 @@ make purchases.</p>
   </div>
 
   <footer class=footer>
-<!--
-    <p><a href="https://www.paypal.com/cgi-bin/webscr?cmd=_s-xclick&amp;hosted_button_id=VSFAVRMSSEW36&amp;source=url" target="_blank" rel="noopener"><img class="aligncenter wp-image-333 size-full" src="/assets/paypal-button.png" alt="Donate now via PayPal" width="100" height="49"></a></p>
--->
-    <p><a href="https://www.paypal.com/donate/?hosted_button_id=9S5EZGFUNTFNQ;source=url" target="_blank" rel="noopener"><img class="aligncenter wp-image-333 size-full" src="/assets/paypal-button.png" alt="Donate now via PayPal" width="100" height="49"></a></p>
+    <p><a href="https://www.paypal.com/donate/?hosted_button_id=9S5EZGFUNTFNQ" target="_blank" rel="noopener"><img class="aligncenter wp-image-333 size-full" src="/assets/paypal-button.png" alt="Donate now via PayPal" width="100" height="49"></a></p>
     <span class=copyright>First Church of Christ, Scientist</span>
     <address>600 E Melbourne Ave, Melbourne, FL 32901</address>
   </footer>

--- a/public/resources/index.html
+++ b/public/resources/index.html
@@ -143,10 +143,7 @@ Acadia Films in concert with New Hampshire Public Broadcasting (1994, 56 minutes
   </div>
 
   <footer class=footer>
-<!--
-    <p><a href="https://www.paypal.com/cgi-bin/webscr?cmd=_s-xclick&amp;hosted_button_id=VSFAVRMSSEW36&amp;source=url" target="_blank" rel="noopener"><img class="aligncenter wp-image-333 size-full" src="/assets/paypal-button.png" alt="Donate now via PayPal" width="100" height="49"></a></p>
--->
-    <p><a href="https://www.paypal.com/donate/?hosted_button_id=9S5EZGFUNTFNQ;source=url" target="_blank" rel="noopener"><img class="aligncenter wp-image-333 size-full" src="/assets/paypal-button.png" alt="Donate now via PayPal" width="100" height="49"></a></p>
+    <p><a href="https://www.paypal.com/donate/?hosted_button_id=9S5EZGFUNTFNQ" target="_blank" rel="noopener"><img class="aligncenter wp-image-333 size-full" src="/assets/paypal-button.png" alt="Donate now via PayPal" width="100" height="49"></a></p>
     <span class=copyright>First Church of Christ, Scientist</span>
     <address>600 E Melbourne Ave, Melbourne, FL 32901</address>
   </footer>

--- a/public/resources/index.html
+++ b/public/resources/index.html
@@ -143,7 +143,10 @@ Acadia Films in concert with New Hampshire Public Broadcasting (1994, 56 minutes
   </div>
 
   <footer class=footer>
+<!--
     <p><a href="https://www.paypal.com/cgi-bin/webscr?cmd=_s-xclick&amp;hosted_button_id=VSFAVRMSSEW36&amp;source=url" target="_blank" rel="noopener"><img class="aligncenter wp-image-333 size-full" src="/assets/paypal-button.png" alt="Donate now via PayPal" width="100" height="49"></a></p>
+-->
+    <p><a href="https://www.paypal.com/donate/?hosted_button_id=9S5EZGFUNTFNQ;source=url" target="_blank" rel="noopener"><img class="aligncenter wp-image-333 size-full" src="/assets/paypal-button.png" alt="Donate now via PayPal" width="100" height="49"></a></p>
     <span class=copyright>First Church of Christ, Scientist</span>
     <address>600 E Melbourne Ave, Melbourne, FL 32901</address>
   </footer>

--- a/public/services-and-sunday-school/index.html
+++ b/public/services-and-sunday-school/index.html
@@ -106,7 +106,10 @@ lovingly in our nursery by an experienced adult.</p>
   </div>
 
   <footer class=footer>
+<!--
     <p><a href="https://www.paypal.com/cgi-bin/webscr?cmd=_s-xclick&amp;hosted_button_id=VSFAVRMSSEW36&amp;source=url" target="_blank" rel="noopener"><img class="aligncenter wp-image-333 size-full" src="/assets/paypal-button.png" alt="Donate now via PayPal" width="100" height="49"></a></p>
+-->
+    <p><a href="https://www.paypal.com/donate/?hosted_button_id=9S5EZGFUNTFNQ;source=url" target="_blank" rel="noopener"><img class="aligncenter wp-image-333 size-full" src="/assets/paypal-button.png" alt="Donate now via PayPal" width="100" height="49"></a></p>
     <span class=copyright>First Church of Christ, Scientist</span>
     <address>600 E Melbourne Ave, Melbourne, FL 32901</address>
   </footer>

--- a/public/services-and-sunday-school/index.html
+++ b/public/services-and-sunday-school/index.html
@@ -106,10 +106,7 @@ lovingly in our nursery by an experienced adult.</p>
   </div>
 
   <footer class=footer>
-<!--
-    <p><a href="https://www.paypal.com/cgi-bin/webscr?cmd=_s-xclick&amp;hosted_button_id=VSFAVRMSSEW36&amp;source=url" target="_blank" rel="noopener"><img class="aligncenter wp-image-333 size-full" src="/assets/paypal-button.png" alt="Donate now via PayPal" width="100" height="49"></a></p>
--->
-    <p><a href="https://www.paypal.com/donate/?hosted_button_id=9S5EZGFUNTFNQ;source=url" target="_blank" rel="noopener"><img class="aligncenter wp-image-333 size-full" src="/assets/paypal-button.png" alt="Donate now via PayPal" width="100" height="49"></a></p>
+    <p><a href="https://www.paypal.com/donate/?hosted_button_id=9S5EZGFUNTFNQ" target="_blank" rel="noopener"><img class="aligncenter wp-image-333 size-full" src="/assets/paypal-button.png" alt="Donate now via PayPal" width="100" height="49"></a></p>
     <span class=copyright>First Church of Christ, Scientist</span>
     <address>600 E Melbourne Ave, Melbourne, FL 32901</address>
   </footer>

--- a/static/assets/lesson-subject.js
+++ b/static/assets/lesson-subject.js
@@ -27,7 +27,7 @@ window.addEventListener("load", function() {
     "God the Preserver of Man",
     "Is the Universe, Including Man, Evolved by Atomic Force?"
   ];
-  var startDate = moment("2016-06-27");
+  var startDate = moment("2023-12-25");
   var weeksSinceStart = moment().diff(startDate, "weeks");
   var subjectIndex = weeksSinceStart % subjects.length;
   var currentSubject = subjects[subjectIndex];

--- a/templates/page.html
+++ b/templates/page.html
@@ -59,10 +59,7 @@
   </div>
 
   <footer class=footer>
-<!--
-    <p><a href="https://www.paypal.com/cgi-bin/webscr?cmd=_s-xclick&amp;hosted_button_id=VSFAVRMSSEW36&amp;source=url" target="_blank" rel="noopener"><img class="aligncenter wp-image-333 size-full" src="/assets/paypal-button.png" alt="Donate now via PayPal" width="100" height="49"></a></p>
--->
-    <p><a href="https://www.paypal.com/donate/?hosted_button_id=9S5EZGFUNTFNQ;source=url" target="_blank" rel="noopener"><img class="aligncenter wp-image-333 size-full" src="/assets/paypal-button.png" alt="Donate now via PayPal" width="100" height="49"></a></p>
+    <p><a href="https://www.paypal.com/donate/?hosted_button_id=9S5EZGFUNTFNQ" target="_blank" rel="noopener"><img class="aligncenter wp-image-333 size-full" src="/assets/paypal-button.png" alt="Donate now via PayPal" width="100" height="49"></a></p>
     <span class=copyright>First Church of Christ, Scientist</span>
     <address>600 E Melbourne Ave, Melbourne, FL 32901</address>
   </footer>

--- a/templates/page.html
+++ b/templates/page.html
@@ -59,7 +59,10 @@
   </div>
 
   <footer class=footer>
+<!--
     <p><a href="https://www.paypal.com/cgi-bin/webscr?cmd=_s-xclick&amp;hosted_button_id=VSFAVRMSSEW36&amp;source=url" target="_blank" rel="noopener"><img class="aligncenter wp-image-333 size-full" src="/assets/paypal-button.png" alt="Donate now via PayPal" width="100" height="49"></a></p>
+-->
+    <p><a href="https://www.paypal.com/donate/?hosted_button_id=9S5EZGFUNTFNQ;source=url" target="_blank" rel="noopener"><img class="aligncenter wp-image-333 size-full" src="/assets/paypal-button.png" alt="Donate now via PayPal" width="100" height="49"></a></p>
     <span class=copyright>First Church of Christ, Scientist</span>
     <address>600 E Melbourne Ave, Melbourne, FL 32901</address>
   </footer>


### PR DESCRIPTION
and fix Bible Lesson Subject off by one

You'll probably want to reject this pull request because 
the new PayPal link seems to be broken. 
I got the link by entering this URL from an email from Sue. It said:
Please donate here:  https://bit.ly/Donate2csspacecoast
When opened, that showed this URL: https://www.paypal.com/donate/?hosted_button_id=9S5EZGFUNTFNQ
That's what I put into templates/page.html, but it seems to be broken.

But I also had these specific instructions from Sue:
>>>> Donate button for website:  <form action="https://www.paypal.com/donate" method="post" target="_top">
>>>> <input type="hidden" name="hosted_button_id" value="BCX3Z3C8HJNJG" />
>>>> <input type="image" src="https://www.paypalobjects.com/en_US/i/btn/btn_donate_LG.gif" border="0" name="submit" title="PayPal - The safer, easier way to pay online!" alt="Donate with PayPal button" />
>>>> <img alt="" border="0" src="https://www.paypal.com/en_US/i/scr/pixel.gif" width="1" height="1" />
>>>> </form>

Perhaps you could fix it to what you think it should be - or just tell me :-)