### PR TITLE
Re-write the lesson subject code to be more reliable (hopefully)

### DIFF
--- a/public/assets/lesson-subject.js
+++ b/public/assets/lesson-subject.js
@@ -1,5 +1,30 @@
-window.addEventListener("load", function() {
-  var subjects = [
+document.addEventListener("DOMContentLoaded", (e) => {
+  const subjects = [
+    "God",
+    "Sacrament",
+    "Life",
+    "Truth",
+    "Love",
+    "Spirit",
+    "Soul",
+    "Mind",
+    "Christ Jesus",
+    "Man",
+    "Substance",
+    "Matter",
+    "Reality",
+    "Unreality",
+    "Are Sin, Disease, and Death Real?",
+    "Doctrine of Atonement",
+    "Probation After Death",
+    "Everlasting Punishment",
+    "Adam and Fallen Man",
+    "Mortals and Immortals",
+    "Soul and Body",
+    "Ancient and Modern Necromancy, alias Mesmerism and Hypnotism, Denounced",
+    "God the Only Cause and Creator",
+    "God the Preserver of Man",
+    "Is the Universe, Including Man, Evolved by Atomic Force?",
     "Christian Science",
     "God",
     "Sacrament",
@@ -25,12 +50,23 @@ window.addEventListener("load", function() {
     "Ancient and Modern Necromancy, alias Mesmerism and Hypnotism, Denounced",
     "God the Only Cause and Creator",
     "God the Preserver of Man",
-    "Is the Universe, Including Man, Evolved by Atomic Force?"
+    "Is the Universe, Including Man, Evolved by Atomic Force?",
+    "Christian Science",
+    "Christ Jesus (probably? it's a 53rd Sunday)",
   ];
-  var startDate = moment("2023-12-25");
-  var weeksSinceStart = moment().diff(startDate, "weeks");
-  var subjectIndex = weeksSinceStart % subjects.length;
-  var currentSubject = subjects[subjectIndex];
+  const now = new Date();
+  const nextSunday = getNextSunday(new Date(Date.UTC(now.getFullYear(), now.getMonth(), now.getDate()+6)));
+  const yearFirstSunday = getNextSunday(new Date(Date.UTC(nextSunday.getUTCFullYear(), 0, 1)));
+  const weekMillis = 1000 * 60 * 60 * 24 * 7;
+  const sundayNumber = Math.floor((nextSunday - yearFirstSunday) / weekMillis);
+  const currentSubject = subjects[sundayNumber];
   var subjectSpan = document.getElementById("bible-lesson-subject");
   subjectSpan.innerHTML = currentSubject;
 });
+
+function getNextSunday(d) {
+  if (d.getUTCDay() != 0) {
+    d.setUTCDate(d.getUTCDate() + (7 - d.getUTCDay()));
+  }
+  return d;
+}

--- a/public/index.html
+++ b/public/index.html
@@ -133,7 +133,6 @@ the writings of Mary Baker Eddy, and Christian Science publications.</p>
     <span class=copyright>First Church of Christ, Scientist</span>
     <address>600 E Melbourne Ave, Melbourne, FL 32901</address>
   </footer>
-  <script src="https://cdnjs.cloudflare.com/ajax/libs/moment.js/2.24.0/moment.min.js" integrity="sha256-4iQZ6BVL4qNKlQ27TExEhBN1HFPvAvAMbFavKKosSWQ=" crossorigin=anonymous></script>
   <script src="/assets/lesson-subject.js"></script>
 </body>
 </html>

--- a/public/lectures-and-events/Be_Set_Free_2024/index.html
+++ b/public/lectures-and-events/Be_Set_Free_2024/index.html
@@ -86,7 +86,6 @@ Member of the Christian Science Board of Lectureship</p>
     <span class=copyright>First Church of Christ, Scientist</span>
     <address>600 E Melbourne Ave, Melbourne, FL 32901</address>
   </footer>
-  <script src="https://cdnjs.cloudflare.com/ajax/libs/moment.js/2.24.0/moment.min.js" integrity="sha256-4iQZ6BVL4qNKlQ27TExEhBN1HFPvAvAMbFavKKosSWQ=" crossorigin=anonymous></script>
   <script src="/assets/lesson-subject.js"></script>
 </body>
 </html>

--- a/public/lectures-and-events/learning-to-love-your-enemies/index.html
+++ b/public/lectures-and-events/learning-to-love-your-enemies/index.html
@@ -86,7 +86,6 @@ First Church of Christ, Scientist, Melbourne</p>
     <span class=copyright>First Church of Christ, Scientist</span>
     <address>600 E Melbourne Ave, Melbourne, FL 32901</address>
   </footer>
-  <script src="https://cdnjs.cloudflare.com/ajax/libs/moment.js/2.24.0/moment.min.js" integrity="sha256-4iQZ6BVL4qNKlQ27TExEhBN1HFPvAvAMbFavKKosSWQ=" crossorigin=anonymous></script>
   <script src="/assets/lesson-subject.js"></script>
 </body>
 </html>

--- a/public/online-services/index.html
+++ b/public/online-services/index.html
@@ -75,7 +75,6 @@ feature and wait for the usher to call on you.</p>
     <span class=copyright>First Church of Christ, Scientist</span>
     <address>600 E Melbourne Ave, Melbourne, FL 32901</address>
   </footer>
-  <script src="https://cdnjs.cloudflare.com/ajax/libs/moment.js/2.24.0/moment.min.js" integrity="sha256-4iQZ6BVL4qNKlQ27TExEhBN1HFPvAvAMbFavKKosSWQ=" crossorigin=anonymous></script>
   <script src="/assets/lesson-subject.js"></script>
 </body>
 </html>

--- a/public/reading-room/index.html
+++ b/public/reading-room/index.html
@@ -87,7 +87,6 @@ make purchases.</p>
     <span class=copyright>First Church of Christ, Scientist</span>
     <address>600 E Melbourne Ave, Melbourne, FL 32901</address>
   </footer>
-  <script src="https://cdnjs.cloudflare.com/ajax/libs/moment.js/2.24.0/moment.min.js" integrity="sha256-4iQZ6BVL4qNKlQ27TExEhBN1HFPvAvAMbFavKKosSWQ=" crossorigin=anonymous></script>
   <script src="/assets/lesson-subject.js"></script>
 </body>
 </html>

--- a/public/resources/index.html
+++ b/public/resources/index.html
@@ -142,7 +142,6 @@ of today. Available in several print and audio editions.</p>
     <span class=copyright>First Church of Christ, Scientist</span>
     <address>600 E Melbourne Ave, Melbourne, FL 32901</address>
   </footer>
-  <script src="https://cdnjs.cloudflare.com/ajax/libs/moment.js/2.24.0/moment.min.js" integrity="sha256-4iQZ6BVL4qNKlQ27TExEhBN1HFPvAvAMbFavKKosSWQ=" crossorigin=anonymous></script>
   <script src="/assets/lesson-subject.js"></script>
 </body>
 </html>

--- a/public/services-and-sunday-school/index.html
+++ b/public/services-and-sunday-school/index.html
@@ -112,7 +112,6 @@ lovingly in our nursery by an experienced adult.</p>
     <span class=copyright>First Church of Christ, Scientist</span>
     <address>600 E Melbourne Ave, Melbourne, FL 32901</address>
   </footer>
-  <script src="https://cdnjs.cloudflare.com/ajax/libs/moment.js/2.24.0/moment.min.js" integrity="sha256-4iQZ6BVL4qNKlQ27TExEhBN1HFPvAvAMbFavKKosSWQ=" crossorigin=anonymous></script>
   <script src="/assets/lesson-subject.js"></script>
 </body>
 </html>

--- a/static/assets/lesson-subject.js
+++ b/static/assets/lesson-subject.js
@@ -1,5 +1,30 @@
-window.addEventListener("load", function() {
-  var subjects = [
+document.addEventListener("DOMContentLoaded", (e) => {
+  const subjects = [
+    "God",
+    "Sacrament",
+    "Life",
+    "Truth",
+    "Love",
+    "Spirit",
+    "Soul",
+    "Mind",
+    "Christ Jesus",
+    "Man",
+    "Substance",
+    "Matter",
+    "Reality",
+    "Unreality",
+    "Are Sin, Disease, and Death Real?",
+    "Doctrine of Atonement",
+    "Probation After Death",
+    "Everlasting Punishment",
+    "Adam and Fallen Man",
+    "Mortals and Immortals",
+    "Soul and Body",
+    "Ancient and Modern Necromancy, alias Mesmerism and Hypnotism, Denounced",
+    "God the Only Cause and Creator",
+    "God the Preserver of Man",
+    "Is the Universe, Including Man, Evolved by Atomic Force?",
     "Christian Science",
     "God",
     "Sacrament",
@@ -25,12 +50,23 @@ window.addEventListener("load", function() {
     "Ancient and Modern Necromancy, alias Mesmerism and Hypnotism, Denounced",
     "God the Only Cause and Creator",
     "God the Preserver of Man",
-    "Is the Universe, Including Man, Evolved by Atomic Force?"
+    "Is the Universe, Including Man, Evolved by Atomic Force?",
+    "Christian Science",
+    "Christ Jesus (probably? it's a 53rd Sunday)",
   ];
-  var startDate = moment("2023-12-25");
-  var weeksSinceStart = moment().diff(startDate, "weeks");
-  var subjectIndex = weeksSinceStart % subjects.length;
-  var currentSubject = subjects[subjectIndex];
+  const now = new Date();
+  const nextSunday = getNextSunday(new Date(Date.UTC(now.getFullYear(), now.getMonth(), now.getDate()+6)));
+  const yearFirstSunday = getNextSunday(new Date(Date.UTC(nextSunday.getUTCFullYear(), 0, 1)));
+  const weekMillis = 1000 * 60 * 60 * 24 * 7;
+  const sundayNumber = Math.floor((nextSunday - yearFirstSunday) / weekMillis);
+  const currentSubject = subjects[sundayNumber];
   var subjectSpan = document.getElementById("bible-lesson-subject");
   subjectSpan.innerHTML = currentSubject;
 });
+
+function getNextSunday(d) {
+  if (d.getUTCDay() != 0) {
+    d.setUTCDate(d.getUTCDate() + (7 - d.getUTCDay()));
+  }
+  return d;
+}

--- a/templates/page.html
+++ b/templates/page.html
@@ -63,7 +63,6 @@
     <span class=copyright>First Church of Christ, Scientist</span>
     <address>600 E Melbourne Ave, Melbourne, FL 32901</address>
   </footer>
-  <script src="https://cdnjs.cloudflare.com/ajax/libs/moment.js/2.24.0/moment.min.js" integrity="sha256-4iQZ6BVL4qNKlQ27TExEhBN1HFPvAvAMbFavKKosSWQ=" crossorigin=anonymous></script>
   <script src="/assets/lesson-subject.js"></script>
 </body>
 </html>


### PR DESCRIPTION
The previous code started from a fixed date in the past and simply cycled through the lesson subjects. More recently, I learned that an extra lesson is usually (always?) inserted in years with 53 Sundays.

The new code looks ahead to the upcoming Sunday and figures out how many Sundays into the year it is, then uses that number as the index into the array of lesson subjects (which is now 53 items long). This code assumes that the additional lesson in a 53-Sunday year is always the final Sunday of the year, but I'm not sure if that is always true. (I haven't been able to find historical data about lesson subjects, so I haven't been able to verify my assumptions.)