### PR TITLE
Duplicate the announcement banner on resources.md

### DIFF
--- a/content/resources.md
+++ b/content/resources.md
@@ -4,9 +4,9 @@ path = "/resources/"
 +++
 
 <aside class="announcement-banner">
-  <a href="/lectures-and-events/learning-to-love-your-enemies/">
+  <a href="/lectures-and-events/the-science-of-god-and-its-power-to-heal-us/">
     <strong>Upcoming lecture:</strong>
-    “<u>Learning to Love Your Enemies</u>” by Giulia Nesi Tetreau on Monday, Feb 17, at 6:30 pm, at the First Church of Christ, Scientist, Cocoa.
+    “<u>The Science of God and Its Power To Heal Us</u>” by Nikki O’Hagan on Thursday, March 12, at 7:00 pm, at Premiere&nbsp;Theaters&nbsp;Oaks&nbsp;10,&nbsp;Melbourne.
   </a>
 </aside>
 

--- a/public/lectures-and-events/the-science-of-god-and-its-power-to-heal-us/index.html
+++ b/public/lectures-and-events/the-science-of-god-and-its-power-to-heal-us/index.html
@@ -68,7 +68,7 @@ Melbourne, FL, and Cocoa, FL</p>
 <h2 id="Location:_Premiere_Theaters_Oaks_10,_Melbourne">Location: Premiere Theaters Oaks 10, Melbourne</h2>
 <iframe src="https://www.google.com/maps/embed?pb=!1m18!1m12!1m3!1d3519.9752742584096!2d-80.65486372451903!3d28.08629707596749!2m3!1f0!2f0!3f0!3m2!1i1024!2i768!4f13.1!3m3!1m2!1s0x88de0e128a46d259%3A0x9d43d7219e7be8e3!2sPremiere%20Theaters%20Oaks%2010!5e0!3m2!1sen!2sus!4v1761097522849!5m2!1sen!2sus" width="400" height="300" style="border:0;" allowfullscreen="" loading="lazy" referrerpolicy="no-referrer-when-downgrade"></iframe>
 <address>1800 W Hibiscus Blvd<br>Melbourne, FL 32901</address>
-<p>For more information, contact
+<p>For more information, contact 
 <a href="mailto:info@csspacecoast.org">info@csspacecoast.org</a> or <a href="mailto:csclerkcocoafl@gmail.com">csclerkcocoafl@gmail.com</a></p>
 </div>
 </div>

--- a/public/resources/index.html
+++ b/public/resources/index.html
@@ -42,9 +42,9 @@
     
 
 <aside class="announcement-banner">
-  <a href="/lectures-and-events/learning-to-love-your-enemies/">
+  <a href="/lectures-and-events/the-science-of-god-and-its-power-to-heal-us/">
     <strong>Upcoming lecture:</strong>
-    “<u>Learning to Love Your Enemies</u>” by Giulia Nesi Tetreau on Monday, Feb 17, at 6:30 pm, at the First Church of Christ, Scientist, Cocoa.
+    “<u>The Science of God and Its Power To Heal Us</u>” by Nikki O’Hagan on Thursday, March 12, at 7:00 pm, at Premiere&nbsp;Theaters&nbsp;Oaks&nbsp;10,&nbsp;Melbourne.
   </a>
 </aside>
 <div class="content-and-sidebar">

--- a/public/services-and-sunday-school/index.html
+++ b/public/services-and-sunday-school/index.html
@@ -53,9 +53,9 @@ Each service includes hymn singing by the congregation and an inspirational solo
 <h2 id="Wednesday_Meeting">Wednesday Meeting</h2>
 <p>Join us for our Wednesday evening testimony meeting at <time
 datetime="19:30">7:30 pm</time>. This meeting includes singing hymns and
-listening to readings from the Bible and <em>Science and Health</em> on a
-timely subject. Those in attendance are invited to share testimonies or
-remarks on how they apply the teachings of Christian Science in
+listening to readings from the Bible and <em>Science and Health</em> on a 
+timely subject. Those in attendance are invited to share testimonies or 
+remarks on how they apply the teachings of Christian Science in 
 their daily lives.</p>
 <h2 id="Sunday_School">Sunday School</h2>
 <p>Our Sunday School meets at <time datetime="10:00">10:00 am</time> and is open to
@@ -65,7 +65,7 @@ interpretation, and the Sermon on the Mount.  In class, students learn of God’
 love for them, and how the spiritual and moral teachings of the Bible and
 <em>Science and Health</em> can help them every day, in every situation.</p>
 <h2 id="Childcare">Childcare</h2>
-<p>Infants and children who are too young to attend Sunday School are cared for
+<p>Infants and children who are too young to attend Sunday School are cared for 
 lovingly in our Children’s Room by an experienced adult.</p>
 </section>
 <aside class="left">


### PR DESCRIPTION
The same announcement banner from content/_index.md was needed in resources.md to replace the old lecture banner.